### PR TITLE
feat: Introduced custom components "Months"

### DIFF
--- a/src/components/Months/Months.test.tsx
+++ b/src/components/Months/Months.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import { DayPickerProps } from 'DayPicker';
+
+import { customRender } from 'test/render';
+
+import { defaultClassNames } from 'contexts/DayPicker/defaultClassNames';
+import { Months, MonthsProps } from './Months';
+
+let root: HTMLDivElement;
+
+const testStyles: Record<string, Record<string, unknown>> = {
+  months: { color: 'red' }
+};
+
+const testClassNames: Record<string, string> = {
+  months: 'months_container'
+};
+
+function TestChildren() {
+  return (
+    <>
+      <div role="grid">1</div>
+      <div role="grid">2</div>
+    </>
+  );
+}
+
+function TestEmptyChildren() {
+  return null;
+}
+function setup(
+  { children, ...props }: MonthsProps,
+  dayPickerProps?: DayPickerProps
+) {
+  const view = customRender(
+    <Months {...props}>{children}</Months>,
+    dayPickerProps
+  );
+  root = view.container.firstChild as HTMLDivElement;
+}
+describe('when rendered with children', () => {
+  beforeEach(() => {
+    setup({
+      children: <TestChildren />
+    });
+  });
+  test('months container should have children grids', () => {
+    expect(screen.getAllByRole('grid')).toHaveLength(2);
+  });
+});
+
+describe('when rendered with empty children', () => {
+  beforeEach(() => {
+    setup({
+      children: <TestEmptyChildren />
+    });
+  });
+  test('months container should not have children grids', () => {
+    expect(screen.queryAllByRole('grid')).toHaveLength(0);
+  });
+});
+
+describe('when custom className and styles provided', () => {
+  beforeEach(() => {
+    setup(
+      {
+        children: <TestChildren />
+      },
+      {
+        styles: testStyles,
+        classNames: testClassNames
+      }
+    );
+  });
+  test('months container should have custom class', () => {
+    expect(root).toHaveClass(testClassNames.months);
+  });
+
+  test('months container should not have default class', () => {
+    expect(root).not.toHaveClass(defaultClassNames.months);
+  });
+
+  test('months container should have custom styles', () => {
+    expect(root).toHaveStyle(testStyles.months);
+  });
+});
+
+describe('when no custom className and styles provided', () => {
+  beforeEach(() => {
+    setup(
+      {
+        children: <TestChildren />
+      },
+      {
+        styles: {},
+        classNames: {}
+      }
+    );
+  });
+  test('months container should not have custom class', () => {
+    expect(root).not.toHaveClass(testClassNames.months);
+  });
+
+  test('months container should have default class', () => {
+    expect(root).toHaveClass(defaultClassNames.months);
+  });
+
+  test('months container should not have custom styles', () => {
+    expect(root).not.toHaveStyle(testStyles.months);
+  });
+});

--- a/src/components/Months/Months.tsx
+++ b/src/components/Months/Months.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode } from 'react';
+import { useDayPicker } from 'contexts/DayPicker';
+
+export interface MonthsProps {
+  children: ReactNode;
+}
+
+export function Months({ children }: MonthsProps): JSX.Element {
+  const dayPicker = useDayPicker();
+
+  return (
+    <div
+      className={dayPicker.classNames.months}
+      style={dayPicker.styles.months}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/Months/index.ts
+++ b/src/components/Months/index.ts
@@ -1,0 +1,1 @@
+export * from './Months';

--- a/src/components/Root/Root.test.tsx
+++ b/src/components/Root/Root.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
-import { RenderResult } from '@testing-library/react';
+import { RenderResult, screen } from '@testing-library/react';
 import { addDays } from 'date-fns';
 import { DayPickerProps } from 'DayPicker';
 
@@ -53,6 +53,28 @@ describe('when using the "classNames" prop', () => {
   });
   test('should display the specified number of month grids', () => {
     expect(container.firstChild).toHaveClass('foo');
+  });
+});
+
+describe('when using custom component "months" prop', () => {
+  const TEST_MONTHS_COPY =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+  function TestMonths({ children }: PropsWithChildren) {
+    return (
+      <div>
+        <div>{TEST_MONTHS_COPY}</div>
+        {children}
+      </div>
+    );
+  }
+  beforeEach(() => {
+    setup({ numberOfMonths: 3, components: { Months: TestMonths } });
+  });
+  test('should display the specified number of month grids', () => {
+    expect(queryMonthGrids()).toHaveLength(3);
+  });
+  test('should have copy from custom "Months" component', () => {
+    expect(screen.getByText(TEST_MONTHS_COPY)).toBeInTheDocument();
   });
 });
 

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { DayPickerProps } from 'DayPicker';
 
 import { Month } from 'components/Month';
+import { Months } from 'components/Months';
 import { useDayPicker } from 'contexts/DayPicker';
 import { useFocusContext } from 'contexts/Focus';
 import { useNavigation } from 'contexts/Navigation';
@@ -65,6 +66,8 @@ export function Root({ initialProps }: RootProps): JSX.Element {
       };
     }, {});
 
+  const MonthsComponent = initialProps.components?.Months ?? Months;
+
   return (
     <div
       className={classNames.join(' ')}
@@ -73,14 +76,11 @@ export function Root({ initialProps }: RootProps): JSX.Element {
       id={dayPicker.id}
       {...dataAttributes}
     >
-      <div
-        className={dayPicker.classNames.months}
-        style={dayPicker.styles.months}
-      >
+      <MonthsComponent>
         {navigation.displayMonths.map((month, i) => (
           <Month key={i} displayIndex={i} displayMonth={month} />
         ))}
-      </div>
+      </MonthsComponent>
     </div>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from 'components/HeadRow';
 export * from 'components/IconDropdown';
 export * from 'components/IconRight';
 export * from 'components/IconLeft';
+export * from 'components/Months';
 export * from 'components/Row';
 export * from 'components/WeekNumber';
 

--- a/src/types/DayPickerBase.ts
+++ b/src/types/DayPickerBase.ts
@@ -6,6 +6,7 @@ import { DayProps } from 'components/Day';
 import { DayContentProps } from 'components/DayContent';
 import { DropdownProps } from 'components/Dropdown';
 import { FooterProps } from 'components/Footer';
+import { MonthsProps } from 'components/Months';
 import { RowProps } from 'components/Row';
 import { WeekNumberProps } from 'components/WeekNumber';
 
@@ -346,6 +347,8 @@ export interface CustomComponents {
   IconRight?: (props: StyledComponent) => JSX.Element | null;
   /** The arrow left icon (used for the Navigation buttons). */
   IconLeft?: (props: StyledComponent) => JSX.Element | null;
+  /** The months wrapper */
+  Months?: (props: MonthsProps) => JSX.Element | null;
   /** The component for the table rows. */
   Row?: (props: RowProps) => JSX.Element | null;
   /** The component for the week number in the table rows. */


### PR DESCRIPTION
### Context

As developer I might want to wrap `<DayPicker />` and use [children API](https://react.dev/reference/react/Children) to map over months. For instance I would want to extend pagination to behave like carousel - this seems good use case for using `Children.map`. 
To achieve it we need to be able to host collection of  `<Month />` elements. That's why replacing hardcoded months container by public customisable `<Months />` open additional possibility how library can be consumed. 

### Analysis

```
const AnyComponent = ({children}) => {
  return <p>Count: {Children.count(children)}</p>
}
---
<AnyComponent>
  <DayPicker numberOfMonths={4} />
</AnyComponent/>

--- output
<p>Count: 1</p>

--- with custom Months
const CustomMonths = ({children}) => (<Months><AnyComponent>{children}</AnyComponent></Months>)

<DayPicker numberOfMonths={4} components={Months: CustomMonths}>

--- output
  <p>Count: 4</p>
```

Current implementation will always return only one children because in **Root** component **DIV** element is wrapper on top of months. 


### Solution

With custom `<Months />` component we can have direct access to array children or to do any other customisation. It means library is more flexible without exposing core functionality.
We already can find dedicated `classes and styles` for `months` to allow customisation, that's makes me think that custom component `<Months />` also make sense.

Other approach I've tried was to compose `DayPicker` form existing components like:

```
const DayPicker = () => {
  <Providers>
    <Root>
       <CustomMonths>{months.map(() => <Month />)}</CustomMonths>
    </Root>
  </Providers>
}
``` 
but it is also impossible because `<Month />` is private (I believe for good reasons). 
